### PR TITLE
ヘッダー化とフッター移動

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <body>
     <div class="TOP">
       <div class="div">
-        <div class="frame">
+        <header class="frame">
           <div class="frame-wrapper">
             <div class="div-wrapper"><div class="text-wrapper">Service Name</div></div>
           </div>
@@ -22,31 +22,7 @@
             </div>
             <div class="frame-4"><div class="text-wrapper-2">資料ダウンロード</div></div>
           </div>
-        </div>
-        <footer class="footer">
-          <div class="frame-5">
-            <div class="frame-6">
-              <div class="text-wrapper">Service Name</div>
-              <div class="frame-7">
-                <div class="frame-8">
-                  <div class="frame-9">
-                    <div class="text-wrapper-3">会社概要</div>
-                    <div class="keyboard-arrow-right"><img class="vector" src="img/image.svg" alt="矢印アイコン" /></div>
-                  </div>
-                  <div class="frame-9">
-                    <div class="text-wrapper-3">個人情報保護方針</div>
-                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector-9.svg" alt="矢印アイコン" /></div>
-                  </div>
-                  <div class="frame-9">
-                    <div class="text-wrapper-3">お問い合わせ</div>
-                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector-3.svg" alt="矢印アイコン" /></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="frame-10"><div class="text-wrapper-4">© Service Name, Inc.</div></div>
-        </footer>
+        </header>
         <div class="overlap">
           <div class="text-wrapper-5">キャッチコピー<br />商品を端的に説明した文章が入ります。</div>
           <div class="text-wrapper-6">
@@ -329,14 +305,38 @@
               <div class="overlap-group-3"><div class="text-wrapper-28">4</div></div>
             </div>
           </div>
-          <div class="group-10">
-            <div class="text-wrapper-26">サービス利用開始</div>
-            <div class="text-wrapper-27">説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。</div>
-            <div class="group-6">
-              <div class="overlap-group-3"><div class="text-wrapper-28">5</div></div>
-            </div>
+        <div class="group-10">
+          <div class="text-wrapper-26">サービス利用開始</div>
+          <div class="text-wrapper-27">説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。</div>
+          <div class="group-6">
+            <div class="overlap-group-3"><div class="text-wrapper-28">5</div></div>
           </div>
         </div>
+        </div>
+        <footer class="footer">
+          <div class="frame-5">
+            <div class="frame-6">
+              <div class="text-wrapper">Service Name</div>
+              <div class="frame-7">
+                <div class="frame-8">
+                  <div class="frame-9">
+                    <div class="text-wrapper-3">会社概要</div>
+                    <div class="keyboard-arrow-right"><img class="vector" src="img/image.svg" alt="矢印アイコン" /></div>
+                  </div>
+                  <div class="frame-9">
+                    <div class="text-wrapper-3">個人情報保護方針</div>
+                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector-9.svg" alt="矢印アイコン" /></div>
+                  </div>
+                  <div class="frame-9">
+                    <div class="text-wrapper-3">お問い合わせ</div>
+                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector-3.svg" alt="矢印アイコン" /></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="frame-10"><div class="text-wrapper-4">© Service Name, Inc.</div></div>
+        </footer>
       </div>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- ナビ部分を`<header>`タグへ置き換え
- フッターをページ末尾へ移動

## Testing
- `python -m webbrowser index.html`
- `npm test` *(package.json がなくて失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689b4273cb8c83309c1f2180ae49812e