### PR TITLE
feat: add Q label to accordion items

### DIFF
--- a/style.css
+++ b/style.css
@@ -1094,8 +1094,24 @@
   position: relative;
   list-style: none;
   padding: 15px 45px 15px 25px;
+  padding-left: 60px;
   border: none;
   cursor: pointer;
+}
+
+.accordion-test summary::before {
+  content: "Q";
+  position: absolute;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  background: #000;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .accordion-test summary::-webkit-details-marker {


### PR DESCRIPTION
## Summary
- add left padding and Q label in accordion summary

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689bc2f1d4ec8330a4d1d42ce07c3531