### PR TITLE
アコーディオンの幅と余白を調整

### DIFF
--- a/style.css
+++ b/style.css
@@ -1085,15 +1085,15 @@
 
 .accordion-test {
   position: absolute;
-  width: 960px;
+  width: 100%;
   top: 178px;
-  left: 160px;
+  left: 0;
 }
 
 .accordion-test summary {
   position: relative;
   list-style: none;
-  padding: 15px 45px 15px 25px;
+  padding: 20px 60px 20px 60px;
   border: none;
   cursor: pointer;
 }
@@ -1122,6 +1122,6 @@
 }
 
 .accordion-test .contents {
-  padding: 15px 45px;
+  padding: 20px 60px;
   background: #E8ECF7;
 }


### PR DESCRIPTION
## Summary
- アコーディオンをページ幅いっぱいに広げて中央に配置
- summaryとコンテンツの余白を拡大してテキストのバランスを調整

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bc2e487988330aec2768205ddd78f