### PR TITLE
feat: add responsive FAQ accordion

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,29 +129,47 @@
             <div class="section-title-text">よくあるご質問</div>
             <div class="rectangle-2"></div>
           </div>
-          <div class="accordion-test">
-            <details>
-              <summary>パスワード忘れたらどうすればいい？</summary>
-              <div class="contents">
+          <div class="faq-list">
+            <div class="faq-item">
+              <button class="faq-toggle" aria-expanded="false">
+                <span class="faq-q-icon">Q</span>
+                <span class="faq-question-text">パスワード忘れたらどうすればいい？</span>
+                <svg class="faq-arrow" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M7 10l5 5 5-5" stroke="#000" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </button>
+              <div class="faq-answer">
                 <p>ログイン画面の「パスワード忘れた？」リンクから再設定できるよ〜！</p>
               </div>
-            </details>
-            <details>
-              <summary>サブスクのキャンセルってできるの？</summary>
-              <div class="contents">
+            </div>
+            <div class="faq-item">
+              <button class="faq-toggle" aria-expanded="false">
+                <span class="faq-q-icon">Q</span>
+                <span class="faq-question-text">サブスクのキャンセルってできるの？</span>
+                <svg class="faq-arrow" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M7 10l5 5 5-5" stroke="#000" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </button>
+              <div class="faq-answer">
                 <p>マイページにログインして「契約管理」からキャンセルできちゃう☆</p>
               </div>
-            </details>
-            <details>
-              <summary>ファイルアップロードのサイズ制限ある？</summary>
-              <div class="contents">
+            </div>
+            <div class="faq-item">
+              <button class="faq-toggle" aria-expanded="false">
+                <span class="faq-q-icon">Q</span>
+                <span class="faq-question-text">ファイルアップロードのサイズ制限ある？</span>
+                <svg class="faq-arrow" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M7 10l5 5 5-5" stroke="#000" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </button>
+              <div class="faq-answer">
                 <p>最大で10MBまでオッケー！</p>
                 <ul>
                   <li>画像とかPDFも同じく10MBまで〜</li>
                   <li>それ以上なら分割してアップしてねん♡</li>
                 </ul>
               </div>
-            </details>
+            </div>
           </div>
         </div>
         <div class="c-title-main-6">
@@ -339,5 +357,19 @@
         </footer>
       </div>
     </div>
+    <script>
+      document.querySelectorAll('.faq-toggle').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const expanded = btn.getAttribute('aria-expanded') === 'true';
+          btn.setAttribute('aria-expanded', String(!expanded));
+          const answer = btn.nextElementSibling;
+          if (!expanded) {
+            answer.style.maxHeight = answer.scrollHeight + 'px';
+          } else {
+            answer.style.maxHeight = 0;
+          }
+        });
+      });
+    </script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1083,63 +1083,6 @@
   left: 0;
 }
 
-.accordion-test {
-  position: absolute;
-  width: 100%;
-  top: 178px;
-  left: 0;
-}
-
-.accordion-test summary {
-  position: relative;
-  list-style: none;
-  padding: 20px 60px;
-  border: none;
-  cursor: pointer;
-}
-
-.accordion-test summary::before {
-  content: "Q";
-  position: absolute;
-  left: 20px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 24px;
-  height: 24px;
-  background: #000;
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.accordion-test summary::-webkit-details-marker {
-  display: none;
-}
-
-.accordion-test summary::after {
-  position: absolute;
-  width: 15px;
-  height: 15px;
-  top: calc(50% - 10px);
-  right: 25px;
-  border-right: 4px solid #000474;
-  border-bottom: 4px solid #000474;
-  box-sizing: border-box;
-  content: "";
-  transform: rotate(45deg);
-  transition: top 0.4s ease-out, transform 0.4s ease-out;
-}
-
-.accordion-test details[open] summary::after {
-  top: calc(50% - 5px);
-  transform: rotate(-135deg);
-}
-
-.accordion-test .contents {
-  padding: 15px 45px;
-  background: #E8ECF7;
-}
 
 .TOP .request-form {
   width: 960px;
@@ -1184,4 +1127,123 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.faq-list {
+  position: absolute;
+  width: 100%;
+  top: 178px;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.faq-item {
+  width: 960px;
+}
+
+.faq-toggle {
+  width: 100%;
+  height: 89px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px;
+  background: #ffffff;
+  border: 1px solid #eeeeee;
+  border-radius: 4px;
+  box-shadow: 0px 4px 0px #e6ebef;
+  font-family: "Noto Sans-Bold", Helvetica;
+  font-size: 20px;
+  line-height: 30px;
+  color: #000000;
+  cursor: pointer;
+}
+
+.faq-q-icon {
+  width: 40px;
+  height: 40px;
+  background: #000000;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  flex-shrink: 0;
+  font-family: "Noto Sans-Bold", Helvetica;
+  font-size: 20px;
+}
+
+.faq-question-text {
+  margin-left: 24px;
+  flex: 1;
+  text-align: left;
+}
+
+.faq-arrow {
+  transition: transform 0.3s ease;
+  flex-shrink: 0;
+}
+
+.faq-toggle[aria-expanded="true"] .faq-arrow {
+  transform: rotate(180deg);
+}
+
+.faq-toggle[aria-expanded="true"] {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.faq-answer {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease;
+  background: #ffffff;
+  border: 1px solid #eeeeee;
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+  box-shadow: 0px 4px 0px #e6ebef;
+}
+
+.faq-answer p,
+.faq-answer ul {
+  margin: 16px 24px;
+  font-family: "Noto Sans-Regular", Helvetica;
+  font-size: 16px;
+  line-height: 24px;
+  color: #000000;
+}
+
+@media (max-width: 768px) {
+  .faq-item {
+    width: 100%;
+    padding: 0 16px;
+  }
+
+  .faq-toggle {
+    height: auto;
+    padding: 16px;
+  }
+
+  .faq-question-text {
+    font-size: 18px;
+  }
+}
+
+@media (max-width: 480px) {
+  .faq-toggle {
+    padding: 12px;
+  }
+
+  .faq-q-icon {
+    width: 32px;
+    height: 32px;
+    font-size: 16px;
+  }
+
+  .faq-question-text {
+    font-size: 16px;
+  }
 }


### PR DESCRIPTION
## Summary
- build Q&A accordion with Q icon, arrow rotation, and aria-expanded toggle
- add responsive styles for 768px and 480px breakpoints

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689be33448208330876a6c189f2de218