### PR TITLE
FAQ回答スタイルの修正

### DIFF
--- a/style.css
+++ b/style.css
@@ -624,26 +624,6 @@
   white-space: nowrap;
 }
 
-.TOP .faq-answer {
-  position: absolute;
-  top: 113px;
-  left: 40px;
-  font-family: "Noto Sans-Regular", Helvetica;
-  font-weight: 400;
-  color: #000000;
-  font-size: 16px;
-  letter-spacing: 0;
-  line-height: 28.8px;
-  white-space: nowrap;
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-}
-
-.TOP .faq-answer.open {
-  max-height: 1000px;
-}
-
 .TOP .overlap-group-wrapper {
   position: absolute;
   width: 42px;
@@ -1197,6 +1177,8 @@
 }
 
 .faq-answer {
+  position: static;
+  white-space: normal;
   overflow: hidden;
   max-height: 0;
   transition: max-height 0.3s ease;


### PR DESCRIPTION
## Summary
- `.TOP .faq-answer`と`.TOP .faq-answer.open`のブロックを削除し、FAQ回答の位置決めを見直し
- `.faq-answer`に`position: static`と`white-space: normal`を追加し、回答が自然に展開されるよう調整

## Testing
- `npm test` *(missing package.json)*
- `npm install puppeteer` *(403 Forbidden; ブラウザ動作確認は環境制約で実施不可)*

------
https://chatgpt.com/codex/tasks/task_e_689c07d1c4c0833098d93283e4f20175