### PR TITLE
Unify form field sizes

### DIFF
--- a/style.css
+++ b/style.css
@@ -1093,6 +1093,14 @@
   border-radius: 4px;
   font-family: "Noto Sans-Regular", Helvetica;
   font-size: 16px;
+  width: 680px;
+  height: 50px;
+}
+
+.request-form input,
+.request-form select {
+  width: 680px;
+  height: 50px;
 }
 
 .TOP .checkbox-group {
@@ -1235,10 +1243,5 @@
 
   .faq-question-text {
     font-size: 16px;
-  }
-
-  .TOP .request-form {
-    width: calc(100% - 32px);
-    left: 16px;
   }
 }


### PR DESCRIPTION
## Summary
- ensure TOP and request form inputs/selects share consistent width and height
- drop duplicate `.TOP .request-form` media query rules

## Testing
- `npm test` (fails: no package.json)
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689c101e1ee48330b8420c64afcc6d81