### PR TITLE
Center flow step numbers

### DIFF
--- a/style.css
+++ b/style.css
@@ -1014,21 +1014,20 @@
   height: 64px;
   background-color: #000000;
   border-radius: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .TOP .flow-step-number {
-  position: absolute;
-  width: 24px;
-  height: 54px;
-  top: 5px;
-  left: 20px;
+  position: static;
   font-family: "Noto Sans-Bold", Helvetica;
   font-weight: 700;
   color: #ffffff;
   font-size: 32px;
   text-align: center;
   letter-spacing: 0;
-  line-height: 32px;
+  line-height: 64px;
 }
 
 .TOP .group-7 {


### PR DESCRIPTION
## Summary
- center circle content using flex
- remove absolute positioning and size constraints from step numbers for flex centering

## Testing
- `xdg-open index.html` *(fails: command not found)*
- `python -m webbrowser index.html`


------
https://chatgpt.com/codex/tasks/task_e_689c150de3c4833086eb3c5b77105a21