### PR TITLE
fix: use unique ids for privacy policy checkboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,8 @@
             </select>
           </div>
           <div class="form-group checkbox-group">
-            <label><input type="checkbox" id="agree" name="agree" /> プライバシーポリシーに同意する</label>
+            <input type="checkbox" id="agree-top" name="agree-top" />
+            <label for="agree-top">プライバシーポリシーに同意する</label>
           </div>
           <button type="submit" class="form-submit">資料ダウンロード</button>
         </form>
@@ -288,8 +289,8 @@
             </select>
           </div>
           <div class="form-group checkbox-group">
-            <input id="agree" name="agree" type="checkbox" />
-            <label for="agree">プライバシーポリシーに同意する</label>
+            <input id="agree-bottom" name="agree-bottom" type="checkbox" />
+            <label for="agree-bottom">プライバシーポリシーに同意する</label>
           </div>
           <button type="submit">資料ダウンロード</button>
         </form>


### PR DESCRIPTION
## Summary
- give top request form checkbox a unique id `agree-top`
- rename lower form checkbox id to `agree-bottom` and sync labels

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx -y -p jsdom node - <<'NODE' ...` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_689c16f424dc83309e377e5dea50b8d1