### PR TITLE
中央寄せフォームのスタイル調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,25 +264,25 @@
             </div>
           </div>
         </div>
-        <form action="#" method="get">
-          <div>
+        <form action="#" method="get" class="request-form">
+          <div class="form-group">
             <label for="company">貴社名</label>
             <input id="company" name="company" type="text" placeholder="貴社名を入力してください" />
           </div>
-          <div>
+          <div class="form-group">
             <label for="person">担当者名</label>
             <input id="person" name="person" type="text" placeholder="担当者名を入力してください" />
           </div>
-          <div>
+          <div class="form-group">
             <label for="email">メールアドレス</label>
             <input id="email" name="email" type="email" placeholder="メールアドレスを入力してください" />
           </div>
-          <div>
+          <div class="form-group">
             <label for="phone">電話番号</label>
             <input id="phone" name="phone" type="tel" placeholder="電話番号を入力してください" />
             <small>ハイフンなし</small>
           </div>
-          <div>
+          <div class="form-group">
             <label for="purpose">資料請求の目的</label>
             <select id="purpose" name="purpose">
               <option value="">情報収集</option>
@@ -292,7 +292,7 @@
             <input id="agree-bottom" name="agree-bottom" type="checkbox" />
             <label for="agree-bottom">プライバシーポリシーに同意する</label>
           </div>
-          <button type="submit">資料ダウンロード</button>
+          <button type="submit" class="form-submit">資料ダウンロード</button>
         </form>
         <div class="overlap-7">
           <div class="rectangle-4"></div>

--- a/style.css
+++ b/style.css
@@ -1066,18 +1066,24 @@
 .TOP .request-form {
   position: absolute;
   top: 5500px;
-  left: 160px;
-  width: 960px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 960px;
   display: flex;
   flex-direction: column;
   gap: 16px;
   margin: 24px auto;
+  align-items: center;
 }
 
 .TOP .form-group {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  align-items: center;
+  text-align: center;
+  width: 100%;
 }
 
 .TOP .form-group label {
@@ -1092,13 +1098,15 @@
   border-radius: 4px;
   font-family: "Noto Sans-Regular", Helvetica;
   font-size: 16px;
-  width: 680px;
+  width: 100%;
+  max-width: 680px;
   height: 50px;
 }
 
 .request-form input,
 .request-form select {
-  width: 680px;
+  width: 100%;
+  max-width: 680px;
   height: 50px;
 }
 
@@ -1114,7 +1122,7 @@
 }
 
 .TOP .form-submit {
-  align-self: flex-start;
+  align-self: center;
   padding: 12px 24px;
   background-color: #000000;
   color: #ffffff;
@@ -1231,7 +1239,6 @@
 
   .TOP .request-form {
     width: calc(100% - 32px);
-    left: 16px;
   }
 }
 


### PR DESCRIPTION
## Summary
- `.TOP .request-form` と `.TOP .form-group` を中央揃え＆レスポンシブ対応に更新
- 後半フォームへ `request-form`・`form-group` クラスを追加して既存スタイルを適用
- ボタン含む各フィールドの幅を調整し見た目を統一

## Testing
- `npm test` (package.json が無くて失敗)


------
https://chatgpt.com/codex/tasks/task_e_689c17f7b33083308fc29f4c8adda96c