### PR TITLE
CTAボタンとフォームボタンのスタイル統一

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                 <img class="phone-icon" src="img/PhoneFilled.png" alt="電話アイコン" />
                 <div class="phone-number">0120-0000-0000</div>
               </div>
-              <div class="header-cta-button"><div class="header-cta-text">資料ダウンロード</div></div>
+              <div class="header-cta-button download-button"><div class="cta-button-text">資料ダウンロード</div></div>
           </div>
         </header>
           <div class="overlap">
@@ -28,7 +28,7 @@
             <div class="hero-description">
             サービス概要が入ります。サービス概要が入ります。<br />サービス概要が入ります。
           </div>
-            <div class="hero-cta-button"><div class="cta-button-text">資料ダウンロード</div></div>
+            <div class="hero-cta-button download-button"><div class="cta-button-text">資料ダウンロード</div></div>
         </div>
           <div class="client-logos">
             <div class="client-logo"><div class="client-logo-text">導入企業ロゴ</div></div>
@@ -109,7 +109,7 @@
             </div>
           </div>
           <div class="overlap-group">
-            <div class="banner-cta-button"><div class="cta-button-text">資料ダウンロード</div></div>
+            <div class="banner-cta-button download-button"><div class="cta-button-text">資料ダウンロード</div></div>
             <img class="polygon" src="img/Polygon%201.png" alt="ポリゴンアイコン" />
           <div class="photo-outlined-wrapper">
             <div class="vector-wrapper"><img class="vector-2" src="img/vector.png" alt="アイコン" /></div>
@@ -117,11 +117,11 @@
           <div class="service-name-sdgs">Service Nameで<br />定着率アップとSDGs研修をはじめられます！</div>
         </div>
           <div class="overlap-2">
-            <div class="section-cta-button"><div class="cta-button-text">資料ダウンロード</div></div>
+            <div class="section-cta-button download-button"><div class="cta-button-text">資料ダウンロード</div></div>
             <div class="cta-description">詳しい特徴や価格についての<br />資料ダウンロード</div>
           </div>
           <div class="overlap-3">
-            <div class="section-cta-button"><div class="cta-button-text">資料ダウンロード</div></div>
+            <div class="section-cta-button download-button"><div class="cta-button-text">資料ダウンロード</div></div>
             <div class="cta-description">導入事例についての<br />資料ダウンロード</div>
           </div>
         <div class="overlap-4">
@@ -206,7 +206,7 @@
             <input type="checkbox" id="agree-top" name="agree-top" />
             <label for="agree-top">プライバシーポリシーに同意する</label>
           </div>
-          <button type="submit" class="form-submit">資料ダウンロード</button>
+          <button type="submit" class="form-submit download-button">資料ダウンロード</button>
         </form>
         <div class="case-studies">
           <div class="paper">
@@ -292,7 +292,7 @@
             <input id="agree-bottom" name="agree-bottom" type="checkbox" />
             <label for="agree-bottom">プライバシーポリシーに同意する</label>
           </div>
-          <button type="submit" class="form-submit">資料ダウンロード</button>
+          <button type="submit" class="form-submit download-button">資料ダウンロード</button>
         </form>
         <div class="overlap-7">
           <div class="rectangle-4"></div>

--- a/style.css
+++ b/style.css
@@ -81,27 +81,22 @@
   height: 28px;
 }
 
+.TOP .download-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background-color: #000000;
+  border-radius: 4px;
+  color: #ffffff;
+}
+
 .TOP .header-cta-button {
   display: inline-flex;
   align-items: flex-start;
   padding: 12px 24px;
   position: relative;
   flex: 0 0 auto;
-  background-color: #000000;
-  border-radius: 4px;
-}
-
-.TOP .header-cta-text {
-  width: fit-content;
-  margin-top: -1.00px;
-  font-family: "Noto Sans-Bold", Helvetica;
-  font-weight: 700;
-  color: #ffffff;
-  font-size: 20px;
-  line-height: 30px;
-  white-space: nowrap;
-  position: relative;
-  letter-spacing: 0;
 }
 
 .TOP .footer {
@@ -261,16 +256,10 @@
 }
 
 .TOP .hero-cta-button {
-  display: flex;
   width: 343px;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
   position: absolute;
   top: 262px;
   left: 469px;
-  background-color: #000000;
-  border-radius: 4px;
 }
 
 .TOP .cta-button-text {
@@ -476,16 +465,10 @@
 }
 
 .TOP .banner-cta-button {
-  display: flex;
   width: 343px;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
   position: absolute;
   top: 487px;
   left: 468px;
-  background-color: #000000;
-  border-radius: 4px;
 }
 
 .TOP .polygon {
@@ -537,16 +520,10 @@
 }
 
 .TOP .section-cta-button {
-  display: flex;
   width: 343px;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
   position: absolute;
   top: 204px;
   left: 468px;
-  background-color: #000000;
-  border-radius: 4px;
 }
 
 .TOP .cta-description {
@@ -1124,12 +1101,10 @@
 .TOP .form-submit {
   align-self: center;
   padding: 12px 24px;
-  background-color: #000000;
-  color: #ffffff;
   font-family: "Noto Sans-Bold", Helvetica;
-  font-size: 20px;
+  font-size: 24px;
+  line-height: 24px;
   border: none;
-  border-radius: 4px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- ヘッダーCTAを含む全ての資料ダウンロードボタンに `download-button` クラスを追加
- `.header-cta-text` を廃止し、`cta-button-text` に統一
- フォーム送信ボタンの文字サイズ・行間を24pxに調整

## Testing
- `npm test` (package.jsonがなく失敗)

------
https://chatgpt.com/codex/tasks/task_e_689c195a2610833096fbb051a5ef1cd2