### PR TITLE
Align TOP form-group elements to left

### DIFF
--- a/style.css
+++ b/style.css
@@ -1058,8 +1058,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  align-items: center;
-  text-align: center;
+  align-items: flex-start;
+  text-align: left;
   width: 100%;
 }
 
@@ -1095,7 +1095,7 @@
 .TOP .checkbox-group {
   flex-direction: row;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .TOP .form-submit {


### PR DESCRIPTION
## Summary
- Align labels and inputs in `.TOP .form-group` to the left
- Left-align checkbox group items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1b72893c8330aafe5f3b6fb6fed6