### PR TITLE
refactor: remove absolute positioning from request form

### DIFF
--- a/style.css
+++ b/style.css
@@ -1041,17 +1041,14 @@
 
 
 .TOP .request-form {
-  position: absolute;
-  top: 5500px;
-  left: 50%;
-  transform: translateX(-50%);
   width: 100%;
   max-width: 960px;
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin: 24px auto;
   align-items: center;
+  margin: 80px auto;
+  padding: 40px 16px;
 }
 
 .TOP .form-group {


### PR DESCRIPTION
## Summary
- remove absolute layout from `.TOP .request-form`
- space the section with margin/padding instead of fixed top offset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1c4db6f48330ad85eb869318f084