### PR TITLE
Move request form under request materials section

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,39 @@
           <div class="section-title-text">まずは資料請求</div>
           <div class="rectangle-2"></div>
         </div>
+        <form action="#" method="post" class="request-form">
+          <div class="form-group">
+            <label for="company">貴社名</label>
+            <input id="company" name="company" type="text" placeholder="貴社名を入力してください" required />
+          </div>
+          <div class="form-group">
+            <label for="person">担当者名</label>
+            <input id="person" name="person" type="text" placeholder="担当者名を入力してください" required />
+          </div>
+          <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input id="email" name="email" type="email" placeholder="メールアドレスを入力してください" required />
+          </div>
+          <div class="form-group">
+            <label for="phone">電話番号</label>
+            <input id="phone" name="phone" type="tel" placeholder="電話番号を入力してください" required />
+            <small>ハイフンなし</small>
+          </div>
+          <div class="form-group">
+            <label for="purpose">資料請求の目的</label>
+            <select id="purpose" name="purpose" required>
+              <option value="">選択してください</option>
+              <option value="info">情報収集</option>
+              <option value="compare">比較検討</option>
+              <option value="introduce">導入予定</option>
+            </select>
+          </div>
+          <div class="form-group checkbox-group">
+            <input id="agree-bottom" name="agree-bottom" type="checkbox" required />
+            <label for="agree-bottom">プライバシーポリシーに同意する</label>
+          </div>
+          <button type="submit" class="form-submit download-button">資料ダウンロード</button>
+        </form>
         <div class="case-studies">
           <div class="paper">
             <div class="card-elements">
@@ -232,39 +265,6 @@
             </div>
           </div>
         </div>
-        <form action="#" method="post" class="request-form">
-          <div class="form-group">
-            <label for="company">貴社名</label>
-            <input id="company" name="company" type="text" placeholder="貴社名を入力してください" required />
-          </div>
-          <div class="form-group">
-            <label for="person">担当者名</label>
-            <input id="person" name="person" type="text" placeholder="担当者名を入力してください" required />
-          </div>
-          <div class="form-group">
-            <label for="email">メールアドレス</label>
-            <input id="email" name="email" type="email" placeholder="メールアドレスを入力してください" required />
-          </div>
-          <div class="form-group">
-            <label for="phone">電話番号</label>
-            <input id="phone" name="phone" type="tel" placeholder="電話番号を入力してください" required />
-            <small>ハイフンなし</small>
-          </div>
-          <div class="form-group">
-            <label for="purpose">資料請求の目的</label>
-            <select id="purpose" name="purpose" required>
-              <option value="">選択してください</option>
-              <option value="info">情報収集</option>
-              <option value="compare">比較検討</option>
-              <option value="introduce">導入予定</option>
-            </select>
-          </div>
-          <div class="form-group checkbox-group">
-            <input id="agree-bottom" name="agree-bottom" type="checkbox" required />
-            <label for="agree-bottom">プライバシーポリシーに同意する</label>
-          </div>
-          <button type="submit" class="form-submit download-button">資料ダウンロード</button>
-        </form>
         <div class="overlap-7">
           <div class="rectangle-4"></div>
           <div class="group-5">

--- a/style.css
+++ b/style.css
@@ -1040,12 +1040,12 @@
 
 .TOP .request-form {
   width: 100%;
-  max-width: 960px;
+  max-width: 680px;
   display: flex;
   flex-direction: column;
   gap: 16px;
   align-items: center;
-  margin: 80px auto;
+  margin: 40px auto;
   padding: 40px 16px;
 }
 


### PR DESCRIPTION
## Summary
- place request form right after the "まずは資料請求" heading
- tweak `.request-form` layout spacing and width for smoother appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c244cb2a483308b02a18490f010d7