### PR TITLE
Move footer directly below request form and relocate sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,30 @@
           </div>
           <button type="submit" class="form-submit download-button">資料ダウンロード</button>
         </form>
+        <footer class="footer">
+          <div class="footer-section">
+            <div class="footer-content">
+              <div class="footer-brand-name">Service Name</div>
+              <div class="footer-links-section">
+                <div class="footer-links">
+                  <div class="footer-link">
+                    <div class="footer-link-text">会社概要</div>
+                    <div class="keyboard-arrow-right"><img class="vector" src="img/image.svg" alt="矢印アイコン" /></div>
+                  </div>
+                  <div class="footer-link">
+                    <div class="footer-link-text">個人情報保護方針</div>
+                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector.png" alt="矢印アイコン" /></div>
+                  </div>
+                  <div class="footer-link">
+                    <div class="footer-link-text">お問い合わせ</div>
+                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector.png" alt="矢印アイコン" /></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="footer-bottom"><div class="footer-copyright-text">© Service Name, Inc.</div></div>
+        </footer>
         <div class="case-studies">
           <div class="paper">
             <div class="card-elements">
@@ -303,30 +327,6 @@
           </div>
         </div>
         </div>
-        <footer class="footer">
-          <div class="footer-section">
-            <div class="footer-content">
-              <div class="footer-brand-name">Service Name</div>
-              <div class="footer-links-section">
-                <div class="footer-links">
-                  <div class="footer-link">
-                    <div class="footer-link-text">会社概要</div>
-                    <div class="keyboard-arrow-right"><img class="vector" src="img/image.svg" alt="矢印アイコン" /></div>
-                  </div>
-                  <div class="footer-link">
-                    <div class="footer-link-text">個人情報保護方針</div>
-                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector.png" alt="矢印アイコン" /></div>
-                  </div>
-                  <div class="footer-link">
-                    <div class="footer-link-text">お問い合わせ</div>
-                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector.png" alt="矢印アイコン" /></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="footer-bottom"><div class="footer-copyright-text">© Service Name, Inc.</div></div>
-        </footer>
       </div>
     </div>
     <script>


### PR DESCRIPTION
## Summary
- place request form immediately after FAQ and move footer right below it
- move case studies and flow sections after the footer

## Testing
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689c27d5115483309fcf01c58b1545c2