### PR TITLE
Reorder sections and move footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,67 +172,7 @@
             </div>
           </div>
         </div>
-        <div class="c-title-main-6">
-          <div class="section-title-text">まずは資料請求</div>
-          <div class="rectangle-2"></div>
         </div>
-        <form action="#" method="post" class="request-form">
-          <div class="form-group">
-            <label for="company">貴社名</label>
-            <input id="company" name="company" type="text" placeholder="貴社名を入力してください" required />
-          </div>
-          <div class="form-group">
-            <label for="person">担当者名</label>
-            <input id="person" name="person" type="text" placeholder="担当者名を入力してください" required />
-          </div>
-          <div class="form-group">
-            <label for="email">メールアドレス</label>
-            <input id="email" name="email" type="email" placeholder="メールアドレスを入力してください" required />
-          </div>
-          <div class="form-group">
-            <label for="phone">電話番号</label>
-            <input id="phone" name="phone" type="tel" placeholder="電話番号を入力してください" required />
-            <small>ハイフンなし</small>
-          </div>
-          <div class="form-group">
-            <label for="purpose">資料請求の目的</label>
-            <select id="purpose" name="purpose" required>
-              <option value="">選択してください</option>
-              <option value="info">情報収集</option>
-              <option value="compare">比較検討</option>
-              <option value="introduce">導入予定</option>
-            </select>
-          </div>
-          <div class="form-group checkbox-group">
-            <input id="agree-bottom" name="agree-bottom" type="checkbox" required />
-            <label for="agree-bottom">プライバシーポリシーに同意する</label>
-          </div>
-          <button type="submit" class="form-submit download-button">資料ダウンロード</button>
-        </form>
-        <footer class="footer">
-          <div class="footer-section">
-            <div class="footer-content">
-              <div class="footer-brand-name">Service Name</div>
-              <div class="footer-links-section">
-                <div class="footer-links">
-                  <div class="footer-link">
-                    <div class="footer-link-text">会社概要</div>
-                    <div class="keyboard-arrow-right"><img class="vector" src="img/image.svg" alt="矢印アイコン" /></div>
-                  </div>
-                  <div class="footer-link">
-                    <div class="footer-link-text">個人情報保護方針</div>
-                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector.png" alt="矢印アイコン" /></div>
-                  </div>
-                  <div class="footer-link">
-                    <div class="footer-link-text">お問い合わせ</div>
-                    <div class="keyboard-arrow-right"><img class="vector" src="img/vector.png" alt="矢印アイコン" /></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="footer-bottom"><div class="footer-copyright-text">© Service Name, Inc.</div></div>
-        </footer>
         <div class="case-studies">
           <div class="paper">
             <div class="card-elements">
@@ -319,14 +259,51 @@
               <div class="overlap-group-3"><div class="flow-step-number">4</div></div>
             </div>
           </div>
-        <div class="group-10">
-          <div class="flow-title">サービス利用開始</div>
-          <div class="flow-description">説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。</div>
-          <div class="group-6">
-            <div class="overlap-group-3"><div class="flow-step-number">5</div></div>
+          <div class="group-10">
+            <div class="flow-title">サービス利用開始</div>
+            <div class="flow-description">説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。</div>
+            <div class="group-6">
+              <div class="overlap-group-3"><div class="flow-step-number">5</div></div>
+            </div>
           </div>
         </div>
+        <div class="c-title-main-6">
+          <div class="section-title-text">まずは資料請求</div>
+          <div class="rectangle-2"></div>
         </div>
+        <form action="#" method="post" class="request-form">
+          <div class="form-group">
+            <label for="company">貴社名</label>
+            <input id="company" name="company" type="text" placeholder="貴社名を入力してください" required />
+          </div>
+          <div class="form-group">
+            <label for="person">担当者名</label>
+            <input id="person" name="person" type="text" placeholder="担当者名を入力してください" required />
+          </div>
+          <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input id="email" name="email" type="email" placeholder="メールアドレスを入力してください" required />
+          </div>
+          <div class="form-group">
+            <label for="phone">電話番号</label>
+            <input id="phone" name="phone" type="tel" placeholder="電話番号を入力してください" required />
+            <small>ハイフンなし</small>
+          </div>
+          <div class="form-group">
+            <label for="purpose">資料請求の目的</label>
+            <select id="purpose" name="purpose" required>
+              <option value="">選択してください</option>
+              <option value="info">情報収集</option>
+              <option value="compare">比較検討</option>
+              <option value="introduce">導入予定</option>
+            </select>
+          </div>
+          <div class="form-group checkbox-group">
+            <input id="agree-bottom" name="agree-bottom" type="checkbox" required />
+            <label for="agree-bottom">プライバシーポリシーに同意する</label>
+          </div>
+          <button type="submit" class="form-submit download-button">資料ダウンロード</button>
+        </form>
       </div>
     </div>
     <script>
@@ -343,5 +320,29 @@
         });
       });
     </script>
+    <footer class="footer">
+      <div class="footer-section">
+        <div class="footer-content">
+          <div class="footer-brand-name">Service Name</div>
+          <div class="footer-links-section">
+            <div class="footer-links">
+              <div class="footer-link">
+                <div class="footer-link-text">会社概要</div>
+                <div class="keyboard-arrow-right"><img class="vector" src="img/image.svg" alt="矢印アイコン" /></div>
+              </div>
+              <div class="footer-link">
+                <div class="footer-link-text">個人情報保護方針</div>
+                <div class="keyboard-arrow-right"><img class="vector" src="img/vector.png" alt="矢印アイコン" /></div>
+              </div>
+              <div class="footer-link">
+                <div class="footer-link-text">お問い合わせ</div>
+                <div class="keyboard-arrow-right"><img class="vector" src="img/vector.png" alt="矢印アイコン" /></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom"><div class="footer-copyright-text">© Service Name, Inc.</div></div>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move case studies and flow sections before the request form
- place footer right before closing body tag

## Testing
- `xdg-open index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c2e22801c8330a7c22ad32b45373e