### PR TITLE
Refactor layout to remove absolute positioning

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,13 +15,13 @@
 
 .TOP .header-container {
   display: flex;
-  width: 1280px;
+  width: 100%;
+  max-width: 1280px;
   align-items: center;
   justify-content: space-between;
   padding: 16px 24px;
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: relative;
+  margin: 0 auto;
   background-color: #ffffff;
   border-bottom-width: 1px;
   border-bottom-style: solid;
@@ -187,11 +187,10 @@
 }
 
 .TOP .vector {
-  position: absolute;
+  position: relative;
   width: 7px;
   height: 12px;
-  top: 6px;
-  left: 9px;
+  margin: 6px 0 0 9px;
 }
 
 .TOP .footer-bottom {
@@ -221,19 +220,22 @@
 }
 
 .TOP .overlap {
-  position: absolute;
-  width: 1280px;
-  height: 366px;
-  top: 86px;
-  left: 0;
+  position: relative;
+  width: 100%;
+  max-width: 1280px;
+  margin: 86px auto 0;
+  padding: 40px 0;
   background-color: #f5f5f5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
 }
 
 .TOP .hero-heading {
-  position: absolute;
-  width: 958px;
-  top: 47px;
-  left: 161px;
+  position: static;
+  width: 100%;
+  max-width: 960px;
   font-family: "Noto Sans-Bold", Helvetica;
   font-weight: 700;
   color: #000000;
@@ -244,10 +246,9 @@
 }
 
 .TOP .hero-description {
-  position: absolute;
-  width: 959px;
-  top: 167px;
-  left: 161px;
+  position: static;
+  width: 100%;
+  max-width: 960px;
   font-family: "Noto Sans-Regular", Helvetica;
   font-weight: 400;
   color: #000000;
@@ -259,9 +260,8 @@
 
 .TOP .hero-cta-button {
   width: 343px;
-  position: absolute;
-  top: 262px;
-  left: 469px;
+  position: static;
+  margin: 0 auto;
 }
 
 .TOP .cta-button-text {
@@ -280,12 +280,12 @@
 
 .TOP .client-logos {
   display: flex;
-  width: 960px;
-  align-items: flex-start;
+  width: 100%;
+  max-width: 960px;
+  align-items: center;
   justify-content: space-between;
-  position: absolute;
-  top: 476px;
-  left: 161px;
+  margin: 40px auto;
+  position: relative;
 }
 
 .TOP .client-logo {
@@ -312,12 +312,11 @@
 }
 
 .TOP .rectangle {
-  position: absolute;
-  width: 1280px;
+  position: relative;
+  width: 100%;
   height: 1px;
-  top: 537px;
-  left: 0;
   background-color: #dddddd;
+  margin: 40px 0;
 }
 
 .TOP .c-title-main {
@@ -325,9 +324,8 @@
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  position: absolute;
-  top: 578px;
-  left: 458px;
+  margin: 40px auto;
+  position: relative;
 }
 
 .TOP .section-title-text {
@@ -351,43 +349,40 @@
 }
 
 .TOP .c-title-main-2 {
-  top: 1753px;
-  left: 612px;
   display: inline-flex;
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  position: absolute;
+  margin: 40px auto;
+  position: relative;
 }
 
 .TOP .c-title-main-3 {
-  top: 2693px;
-  left: 584px;
   display: inline-flex;
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  position: absolute;
+  margin: 40px auto;
+  position: relative;
 }
 
 .TOP .c-title-main-4 {
-  top: 3593px;
-  left: 556px;
   display: inline-flex;
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  position: absolute;
+  margin: 40px auto;
+  position: relative;
 }
 
 .TOP .problem-cards {
   display: flex;
-  width: 960px;
+  width: 100%;
+  max-width: 960px;
   align-items: flex-start;
   gap: 16px;
-  position: absolute;
-  top: 676px;
-  left: 161px;
+  margin: 40px auto;
+  position: relative;
 }
 
 .TOP .card {
@@ -412,16 +407,14 @@
   position: relative;
   width: 64px;
   height: 64px;
-  top: 48px;
-  left: 123px;
+  margin: 48px auto 0;
 }
 
 .TOP .vector-2 {
-  position: absolute;
+  position: relative;
   width: 48px;
   height: 48px;
-  top: 8px;
-  left: 8px;
+  margin: 8px;
 }
 
 .TOP .card-title {
@@ -449,44 +442,41 @@
 
 .TOP .feature-cards {
   display: flex;
-  width: 960px;
+  width: 100%;
+  max-width: 960px;
   align-items: flex-start;
   gap: 16px;
-  position: absolute;
-  top: 1851px;
-  left: 161px;
+  margin: 40px auto;
+  position: relative;
 }
 
 .TOP .overlap-group {
-  position: absolute;
-  width: 1280px;
-  height: 623px;
-  top: 1050px;
-  left: 0;
+  position: relative;
+  width: 100%;
+  max-width: 1280px;
+  margin: 40px auto;
   background-color: #f5f5f5;
 }
 
 .TOP .banner-cta-button {
   width: 343px;
-  position: absolute;
-  top: 487px;
-  left: 468px;
+  position: static;
+  margin: 0 auto;
 }
 
 .TOP .polygon {
-  position: absolute;
+  position: relative;
   width: 831px;
   height: 75px;
-  top: 0;
-  left: 224px;
+  margin: 0 auto;
 }
 
 .TOP .photo-outlined-wrapper {
-  position: absolute;
-  width: 961px;
+  position: relative;
+  width: 100%;
+  max-width: 961px;
   height: 240px;
-  top: 223px;
-  left: 160px;
+  margin: 0 auto;
   background-color: #ffffff;
 }
 
@@ -499,10 +489,9 @@
 }
 
 .TOP .service-name-sdgs {
-  position: absolute;
-  width: 960px;
-  top: 114px;
-  left: 160px;
+  position: static;
+  width: 100%;
+  max-width: 960px;
   font-family: "Noto Sans-Bold", Helvetica;
   font-weight: 700;
   color: #000000;
@@ -510,29 +499,28 @@
   text-align: center;
   letter-spacing: 0;
   line-height: 42px;
+  margin: 0 auto;
 }
 
 .TOP .overlap-2 {
-  position: absolute;
-  width: 1280px;
-  height: 340px;
-  top: 2273px;
-  left: 0;
+  position: relative;
+  width: 100%;
+  max-width: 1280px;
+  margin: 40px auto;
   background-color: #f5f5f5;
+  height: 340px;
 }
 
 .TOP .section-cta-button {
   width: 343px;
-  position: absolute;
-  top: 204px;
-  left: 468px;
+  position: static;
+  margin: 0 auto;
 }
 
 .TOP .cta-description {
-  position: absolute;
-  width: 960px;
-  top: 79px;
-  left: 160px;
+  position: static;
+  width: 100%;
+  max-width: 960px;
   font-family: "Noto Sans-Bold", Helvetica;
   font-weight: 700;
   color: #000000;
@@ -540,40 +528,38 @@
   text-align: center;
   letter-spacing: 0;
   line-height: 42px;
+  margin: 0 auto;
 }
 
 .TOP .overlap-3 {
-  position: absolute;
-  width: 1280px;
-  height: 340px;
-  top: 3173px;
-  left: 0;
+  position: relative;
+  width: 100%;
+  max-width: 1280px;
+  margin: 40px auto;
   background-color: #f5f5f5;
+  height: 340px;
 }
 
 .TOP .overlap-4 {
-  position: absolute;
-  width: 1280px;
-  height: 844px;
-  top: 4501px;
-  left: 0;
+  position: relative;
+  width: 100%;
+  max-width: 1280px;
+  margin: 40px auto;
   background-color: #f5f5f5;
+  padding: 40px 0;
 }
 
 .TOP .group {
-  position: absolute;
-  width: 964px;
-  height: 166px;
-  top: 178px;
-  left: 160px;
+  position: relative;
+  width: 100%;
+  max-width: 964px;
+  margin: 0 auto;
 }
 
 .TOP .overlap-5 {
   position: relative;
   width: 962px;
   height: 168px;
-  top: -1px;
-  left: -1px;
   background-color: #ffffff;
   border-radius: 4px;
   border: 1px solid;
@@ -582,18 +568,16 @@
 }
 
 .TOP .rectangle-3 {
-  position: absolute;
-  width: 880px;
+  position: relative;
+  width: 100%;
+  max-width: 880px;
   height: 1px;
-  top: 88px;
-  left: 40px;
   background-color: #dddddd;
+  margin: 40px auto;
 }
 
 .TOP .faq-question {
-  position: absolute;
-  top: 29px;
-  left: 104px;
+  position: relative;
   font-size: 20px;
   line-height: 30px;
   font-family: "Noto Sans-Bold", Helvetica;
@@ -601,14 +585,14 @@
   color: #000000;
   letter-spacing: 0;
   white-space: nowrap;
+  margin-left: 104px;
 }
 
 .TOP .overlap-group-wrapper {
-  position: absolute;
+  position: relative;
   width: 42px;
   height: 40px;
-  top: 24px;
-  left: 40px;
+  margin-left: 40px;
 }
 
 .TOP .overlap-group-2 {
@@ -617,12 +601,13 @@
   height: 40px;
   background-color: #000000;
   border-radius: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .TOP .faq-letter {
-  position: absolute;
-  top: 9px;
-  left: 10px;
+  position: static;
   font-family: "Noto Sans-Bold", Helvetica;
   font-weight: 700;
   color: #ffffff;
@@ -639,9 +624,8 @@
   align-items: center;
   justify-content: flex-end;
   gap: 10px;
-  position: absolute;
-  top: 24px;
-  left: 880px;
+  position: relative;
+  margin-left: auto;
   transform: rotate(-180.00deg);
   cursor: pointer;
 }
@@ -655,18 +639,16 @@
 }
 
 .TOP .overlap-wrapper {
-  position: absolute;
-  width: 962px;
+  position: relative;
+  width: 100%;
+  max-width: 962px;
   height: 89px;
-  top: 360px;
-  left: 160px;
+  margin: 40px auto;
 }
 
 .TOP .overlap-6 {
   position: relative;
   height: 91px;
-  top: -1px;
-  left: -1px;
   background-color: #ffffff;
   border-radius: 4px;
   border: 1px solid;
@@ -681,9 +663,8 @@
   align-items: center;
   justify-content: flex-end;
   gap: 10px;
-  position: absolute;
-  top: 24px;
-  left: 880px;
+  position: relative;
+  margin-left: auto;
 }
 
 .TOP .arrow-drop-down-2 {
@@ -693,38 +674,23 @@
   flex-grow: 1;
 }
 
-.TOP .group-2 {
-  position: absolute;
-  width: 962px;
-  height: 89px;
-  top: 465px;
-  left: 160px;
-}
-
-.TOP .group-3 {
-  position: absolute;
-  width: 962px;
-  height: 89px;
-  top: 570px;
-  left: 160px;
-}
-
+.TOP .group-2,
+.TOP .group-3,
 .TOP .group-4 {
-  position: absolute;
-  width: 962px;
+  position: relative;
+  width: 100%;
+  max-width: 962px;
   height: 89px;
-  top: 675px;
-  left: 160px;
+  margin: 40px auto;
 }
 
 .TOP .c-title-main-5 {
-  top: 80px;
-  left: 542px;
   display: inline-flex;
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  position: absolute;
+  margin: 40px auto;
+  position: relative;
 }
 
 .TOP .c-title-main-6 {
@@ -872,9 +838,8 @@
   height: 50px;
   align-items: flex-start;
   gap: 3px;
-  position: absolute;
-  top: 5552px;
-  left: 300px;
+  position: relative;
+  margin: 40px auto;
   background-color: #ffffff;
   border-radius: 4px;
   border: 1px solid;
@@ -940,12 +905,10 @@
 }
 
 .TOP .rectangle-4 {
-  position: absolute;
+  position: relative;
   width: 1px;
-  top: 0;
-  bottom: 0;
-  left: 32px;
   background-color: #000000;
+  margin-left: 32px;
 }
 
 .TOP .group-5,
@@ -981,11 +944,9 @@
 }
 
 .TOP .group-6 {
-  position: absolute;
+  position: relative;
   width: 66px;
   height: 64px;
-  top: 0;
-  left: 0;
 }
 
 .TOP .overlap-group-3 {
@@ -1077,14 +1038,13 @@
 }
 
 .faq-list {
-  position: absolute;
+  position: relative;
   width: 100%;
-  top: 178px;
-  left: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 16px;
+  margin: 40px auto 0;
 }
 
 .faq-item {


### PR DESCRIPTION
## Summary
- switch hero and client logo sections to flex-based layout with relative positioning
- refactor FAQ section to remove absolute coordinates and rely on margins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c2fddce8c8330b7fc15d679127bef