### PR TITLE
Make CTA buttons responsive

### DIFF
--- a/style.css
+++ b/style.css
@@ -259,9 +259,11 @@
 }
 
 .TOP .hero-cta-button {
-  width: 343px;
+  width: 100%;
+  max-width: 343px;
   position: static;
   margin: 0 auto;
+  display: block;
 }
 
 .TOP .cta-button-text {
@@ -459,9 +461,11 @@
 }
 
 .TOP .banner-cta-button {
-  width: 343px;
+  width: 100%;
+  max-width: 343px;
   position: static;
   margin: 0 auto;
+  display: block;
 }
 
 .TOP .polygon {
@@ -512,9 +516,11 @@
 }
 
 .TOP .section-cta-button {
-  width: 343px;
+  width: 100%;
+  max-width: 343px;
   position: static;
   margin: 0 auto;
+  display: block;
 }
 
 .TOP .cta-description {


### PR DESCRIPTION
## Summary
- allow hero, banner, and section CTA buttons to stretch to container width while capping at 343px for better responsiveness

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c573c97008330960ef88cd638ff93