### PR TITLE
fix: グレー背景を左右端まで広げるためのスタイル調整

### DIFF
--- a/style.css
+++ b/style.css
@@ -223,14 +223,13 @@
 .TOP .overlap {
   position: relative;
   width: 100%;
-  max-width: 1280px;
-  margin: 86px auto 0;
   padding: 40px 0;
   background-color: #f5f5f5;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 24px;
+  margin: 0;
 }
 
 .TOP .hero-heading {
@@ -456,9 +455,8 @@
 .TOP .overlap-group {
   position: relative;
   width: 100%;
-  max-width: 1280px;
-  margin: 40px auto;
   background-color: #f5f5f5;
+  margin: 0;
 }
 
 .TOP .banner-cta-button {
@@ -510,10 +508,9 @@
 .TOP .overlap-2 {
   position: relative;
   width: 100%;
-  max-width: 1280px;
-  margin: 40px auto;
   background-color: #f5f5f5;
   height: 340px;
+  margin: 0;
 }
 
 .TOP .section-cta-button {
@@ -541,19 +538,17 @@
 .TOP .overlap-3 {
   position: relative;
   width: 100%;
-  max-width: 1280px;
-  margin: 40px auto;
   background-color: #f5f5f5;
   height: 340px;
+  margin: 0;
 }
 
 .TOP .overlap-4 {
   position: relative;
   width: 100%;
-  max-width: 1280px;
-  margin: 40px auto;
   background-color: #f5f5f5;
   padding: 40px 0;
+  margin: 0;
 }
 
 .TOP .group {


### PR DESCRIPTION
## Summary
- overlap関連のセクションから`max-width`と`margin`を削除し、`margin: 0;`を追加して背景が左右端まで広がるようにしました。

## Testing
- `npm test` (package.jsonが無いため実行不可)


------
https://chatgpt.com/codex/tasks/task_e_689c79548c548330bf786ad4c5080a01