### PR TITLE
Service Intro CTAボタンの位置調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,9 +101,6 @@
 
         <!-- Service Intro CTA -->
         <section class="overlap-group">
-          <a href="downloads/資料.pdf" class="banner-cta-button download-button" download>
-            <div class="cta-button-text">資料ダウンロード</div>
-          </a>
           <img class="polygon" src="img/Polygon%201.png" alt="ポリゴンアイコン" />
           <div class="photo-outlined-wrapper">
             <div class="vector-wrapper">
@@ -113,6 +110,9 @@
           <div class="service-name-sdgs">
             Service Nameで<br />定着率アップとSDGs研修をはじめられます！
           </div>
+          <a href="downloads/資料.pdf" class="banner-cta-button download-button" download>
+            <div class="cta-button-text">資料ダウンロード</div>
+          </a>
         </section>
 
         <!-- Features Section -->


### PR DESCRIPTION
## Summary
- move banner download button below service intro text for clearer flow

## Testing
- `npx prettier --check index.html` (fails: Code style issues found in the above file. Run Prettier with --write to fix.)
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689c7aacfa7c833088669b3ee0920cd2