### PR TITLE
Center flow titles

### DIFF
--- a/style.css
+++ b/style.css
@@ -916,13 +916,14 @@
 
 .TOP .flow-title {
   position: static;
-  margin: 16px 0 8px;
+  margin: 16px auto 8px;
   font-family: "Noto Sans-Bold", Helvetica;
   font-weight: 700;
   color: #000000;
   font-size: 25px;
   letter-spacing: 0;
   line-height: normal;
+  text-align: center;
 }
 
 .TOP .flow-description {


### PR DESCRIPTION
## Summary
- Centered the flow section titles with `text-align: center`
- Adjusted margins to keep titles centered

## Testing
- `w3m index.html` (command not found)
- `apt-get update` (403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689c84b2d1d88330810708f6541dfd2d