### PR TITLE
Refactor flow numbering with CSS counters

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,51 +261,53 @@
           </div>
           <div class="overlap-7">
             <div class="rectangle-4"></div>
-            <div class="flow-item">
-              <div class="flow-step-number">①</div>
-              <div class="flow-text">
-                <div class="flow-title">お問い合わせ</div>
-                <div class="flow-description">
-                  説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+            <ol class="flow-list">
+              <li class="flow-item">
+                <div class="flow-step-number"></div>
+                <div class="flow-text">
+                  <div class="flow-title">お問い合わせ</div>
+                  <div class="flow-description">
+                    説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+                  </div>
                 </div>
-              </div>
-            </div>
-            <div class="flow-item">
-              <div class="flow-step-number">②</div>
-              <div class="flow-text">
-                <div class="flow-title">ヒアリング</div>
-                <div class="flow-description">
-                  説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+              </li>
+              <li class="flow-item">
+                <div class="flow-step-number"></div>
+                <div class="flow-text">
+                  <div class="flow-title">ヒアリング</div>
+                  <div class="flow-description">
+                    説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+                  </div>
                 </div>
-              </div>
-            </div>
-            <div class="flow-item">
-              <div class="flow-step-number">③</div>
-              <div class="flow-text">
-                <div class="flow-title">最適なプランのご提案</div>
-                <div class="flow-description">
-                  説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+              </li>
+              <li class="flow-item">
+                <div class="flow-step-number"></div>
+                <div class="flow-text">
+                  <div class="flow-title">最適なプランのご提案</div>
+                  <div class="flow-description">
+                    説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+                  </div>
                 </div>
-              </div>
-            </div>
-            <div class="flow-item">
-              <div class="flow-step-number">④</div>
-              <div class="flow-text">
-                <div class="flow-title">ご契約</div>
-                <div class="flow-description">
-                  説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+              </li>
+              <li class="flow-item">
+                <div class="flow-step-number"></div>
+                <div class="flow-text">
+                  <div class="flow-title">ご契約</div>
+                  <div class="flow-description">
+                    説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+                  </div>
                 </div>
-              </div>
-            </div>
-            <div class="flow-item">
-              <div class="flow-step-number">⑤</div>
-              <div class="flow-text">
-                <div class="flow-title">サービス利用開始</div>
-                <div class="flow-description">
-                  説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+              </li>
+              <li class="flow-item">
+                <div class="flow-step-number"></div>
+                <div class="flow-text">
+                  <div class="flow-title">サービス利用開始</div>
+                  <div class="flow-description">
+                    説明文が入ります。説明文が入ります。説明文が入ります。説明文が入ります。
+                  </div>
                 </div>
-              </div>
-            </div>
+              </li>
+            </ol>
           </div>
         </section>
 

--- a/style.css
+++ b/style.css
@@ -937,6 +937,13 @@
   line-height: 24px;
 }
 
+.TOP .flow-list {
+  counter-reset: flow-step;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .TOP .flow-item {
   display: flex;
   align-items: flex-start;
@@ -944,6 +951,7 @@
 }
 
 .TOP .flow-step-number {
+  counter-increment: flow-step;
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -953,10 +961,14 @@
   justify-content: center;
   align-items: center;
   margin-right: 16px;
-  font-family: "Noto Sans-Bold", Helvetica;
+  font-family: "Noto Sans-Bold", Helvetica, sans-serif;
   font-weight: 700;
   font-size: 20px;
   line-height: 40px;
+}
+
+.TOP .flow-step-number::before {
+  content: counter(flow-step);
 }
 
 .TOP .flow-text {


### PR DESCRIPTION
## Summary
- Replace manual numbered icons with ordered list and CSS counter for "ご利用の流れ"
- Add sans-serif fallback and counter styles for step bubbles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c85c92c9c83309e45f8bf58a8c425