### PR TITLE
Fix CTA button width

### DIFF
--- a/style.css
+++ b/style.css
@@ -271,7 +271,8 @@
 
 .TOP .cta-button-text {
   position: relative;
-  width: fit-content;
+  width: 100%;
+  display: block;
   margin-top: -1.00px;
   font-family: "Noto Sans-Bold", Helvetica;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- Set `.TOP .cta-button-text` width to 100% and display block to keep text centered

## Testing
- `npm test` (fails: Could not read package.json)
- `npx playwright --version` (fails: 403 Forbidden)
- `apt-get update` (fails: repository not signed/403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689c89cf3d348330bb1bb24a15611a4e