### PR TITLE
中央揃いのセクションタイトル

### DIFF
--- a/style.css
+++ b/style.css
@@ -326,7 +326,7 @@
 }
 
 .TOP .c-title-main {
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
   align-items: center;
   gap: 16px;


### PR DESCRIPTION
## 概要
- `.c-title-main` を `display: flex` に変更してセクションタイトルを中央揃いに

## テスト
- `npm test` : パッケージが存在せず実行不可

------
https://chatgpt.com/codex/tasks/task_e_689c8ac51f0c83308901532d856296fe