### PR TITLE
Center polygon image in TOP section

### DIFF
--- a/style.css
+++ b/style.css
@@ -479,6 +479,7 @@
   width: 831px;
   height: 75px;
   margin: 0 auto;
+  display: block;
 }
 
 .TOP .photo-outlined-wrapper {


### PR DESCRIPTION
## Summary
- add display:block to `.TOP .polygon` for centering with margin auto
- verify parent `.overlap-group` layout to ensure no conflicts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d0fe57483309b9bece05f0379c9