### PR TITLE
サービス紹介セクションのレイアウト調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,12 +103,12 @@
         <section class="overlap-group">
           <img class="polygon" src="img/Polygon%201.png" alt="ポリゴンアイコン" />
           <div class="photo-outlined-wrapper">
+            <div class="service-name-sdgs">
+              Service Nameで<br />定着率アップとSDGs研修をはじめられます！
+            </div>
             <div class="vector-wrapper">
               <img class="vector-2" src="img/vector.png" alt="アイコン" />
             </div>
-          </div>
-          <div class="service-name-sdgs">
-            Service Nameで<br />定着率アップとSDGs研修をはじめられます！
           </div>
           <a href="downloads/資料.pdf" class="banner-cta-button download-button" download>
             <div class="cta-button-text">資料ダウンロード</div>

--- a/style.css
+++ b/style.css
@@ -490,11 +490,12 @@
   height: 240px;
   margin: 0 auto;
   background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .TOP .vector-wrapper {
-  top: 88px;
-  left: 449px;
   position: relative;
   width: 64px;
   height: 64px;
@@ -511,7 +512,7 @@
   text-align: center;
   letter-spacing: 0;
   line-height: 42px;
-  margin: 0 auto;
+  margin: 0 auto 16px;
 }
 
 .TOP .overlap-2 {


### PR DESCRIPTION
## Summary
- サービス紹介バナー内のテキストとアイコンをラッパー内にまとめて順序を整理
- ラッパーをflex縦並び＆中央寄せにして、テキスト下にアイコンがくるように調整
- サービス名テキストに余白を足してアイコンとの距離感を確保

## Testing
- `npm test` *(package.jsonがなく失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689c9b0198188330be73a5fa94075d36