### PR TITLE
Service Intro CTAセクションのレイアウト調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,10 +102,10 @@
         <!-- Service Intro CTA -->
         <section class="overlap-group">
           <img class="polygon" src="img/Polygon%201.png" alt="ポリゴンアイコン" />
+          <div class="service-name-sdgs">
+            Service Nameで<br />定着率アップとSDGs研修をはじめられます！
+          </div>
           <div class="photo-outlined-wrapper">
-            <div class="service-name-sdgs">
-              Service Nameで<br />定着率アップとSDGs研修をはじめられます！
-            </div>
             <div class="vector-wrapper">
               <img class="vector-2" src="img/vector.png" alt="アイコン" />
             </div>

--- a/style.css
+++ b/style.css
@@ -488,12 +488,13 @@
   position: relative;
   width: 100%;
   max-width: 961px;
-  height: 240px;
+  height: 160px;
   margin: 0 auto;
   background-color: #ffffff;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
 }
 
 .TOP .vector-wrapper {
@@ -513,7 +514,7 @@
   text-align: center;
   letter-spacing: 0;
   line-height: 42px;
-  margin: 0 auto 16px;
+  margin: 16px auto;
 }
 
 .TOP .overlap-2 {


### PR DESCRIPTION
## Summary
- Service Nameテキストを白枠外へ移動し、アイコン枠のみを保持
- service-name-sdgsの上下余白とphoto-outlined-wrapperの高さ・中央寄せを調整

## Testing
- `npm test` (package.jsonが無く実行不可)


------
https://chatgpt.com/codex/tasks/task_e_689c9e4f257083308a8afddd33389327