### PR TITLE
feat: add white frame for vector image

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
           </div>
           <div class="photo-outlined-wrapper">
             <div class="vector-wrapper">
-              <img class="vector-2" src="img/vector.png" alt="アイコン" />
+              <img class="vector-2" src="img/vector.png" alt="アイコン" width="961" height="240" />
             </div>
           </div>
           <a href="downloads/資料.pdf" class="banner-cta-button download-button" download>

--- a/style.css
+++ b/style.css
@@ -487,21 +487,19 @@
 
 .TOP .photo-outlined-wrapper {
   position: relative;
-  width: 100%;
-  max-width: 961px;
-  height: 160px;
+  width: 961px;
+  height: 240px;
+  border: 1px solid #ffffff;
   margin: 0 auto;
-  background-color: #ffffff;
+  background-color: transparent;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
 }
 
 .TOP .vector-wrapper {
-  position: relative;
-  width: 64px;
-  height: 64px;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- style vector container with white border and fixed size
- ensure vector image fills the frame

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d5a25e9388330be61ede59e883b50