### PR TITLE
fix: hide vector image and set white background

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,11 +105,7 @@
           <div class="service-name-sdgs">
             Service Nameで<br />定着率アップとSDGs研修をはじめられます！
           </div>
-          <div class="photo-outlined-wrapper">
-            <div class="vector-wrapper">
-              <img class="vector-2" src="img/vector.png" alt="アイコン" width="961" height="240" />
-            </div>
-          </div>
+          <div class="photo-outlined-wrapper"></div>
           <a href="downloads/資料.pdf" class="banner-cta-button download-button" download>
             <div class="cta-button-text">資料ダウンロード</div>
           </a>

--- a/style.css
+++ b/style.css
@@ -491,7 +491,7 @@
   height: 240px;
   border: 1px solid #ffffff;
   margin: 0 auto;
-  background-color: transparent;
+  background-color: #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- remove unused vector image from photo-outlined wrapper
- make photo-outlined wrapper white to cover area

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d6a58a0e08330a612b18442ee823e