### PR TITLE
fix: keep vector image with white background

### DIFF
--- a/style.css
+++ b/style.css
@@ -491,7 +491,7 @@
   height: 240px;
   border: 1px solid #ffffff;
   margin: 0 auto;
-  background-color: transparent;
+  background-color: #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- restore vector image inside photo-outlined wrapper
- ensure wrapper stays white to cover background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d6a58a0e08330a612b18442ee823e