### PR TITLE
feat: add form layout styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -913,6 +913,26 @@
   .TOP .flow-title{ font-size: 18px; }
 }
 
+.request-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+}
+
+small {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+}
+
 .request-form input,
 .request-form select {
   width: 100%;


### PR DESCRIPTION
## Summary
- style request form and groups for centered layout
- show helper text below inputs with `small`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ec541449c8330b95a12337366139a